### PR TITLE
added option to suppress browser rendering for fastboot

### DIFF
--- a/app/instance-initializers/browser/head.js
+++ b/app/instance-initializers/browser/head.js
@@ -1,6 +1,9 @@
 import Ember from 'ember';
+import ENV from '../../config/environment';
 
 export function initialize(instance) {
+  if (ENV['ember-cli-head'] && ENV['ember-cli-head']['suppressBrowserRender']) { return true; }
+
   // clear fast booted head (if any)
   Ember.$('meta[name="ember-cli-head-start"]')
     .nextUntil('meta[name="ember-cli-head-end"] ~')


### PR DESCRIPTION
Add configuration property to suppress rendering the head from the browser. This is quite useful when you are using fastboot and you want the head to be the realm of the fastboot server only.