### PR TITLE
Remove harding of isDevelopingAddon.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,6 @@ var filterInitializers = require('fastboot-filter-initializers');
 
 module.exports = {
   name: 'ember-cli-head',
-  isDevelopingAddon: function() {
-    return true;
-  },
 
   treeForApp: function(tree) {
     return filterInitializers(tree);


### PR DESCRIPTION
Hard coding like this forces all consuming applications to run their linting tests against the addon.

This is useful for local debugging, but should not be included when publishing.