### PR TITLE
Remove HTML Comments from head template.

### DIFF
--- a/blueprints/ember-cli-head/files/__root__/templates/head.hbs
+++ b/blueprints/ember-cli-head/files/__root__/templates/head.hbs
@@ -1,4 +1,5 @@
-<!-- `app/templates/head.hbs` -->
-<!-- Add content you wish automatically added to the documents head -->
-<!-- here. The 'model' available in this template can be populated by -->
-<!-- setting values on the 'head-data' service. -->
+{{!-- 
+  Add content you wish automatically added to the documents head
+  here. The 'model' available in this template can be populated by
+  setting values on the 'head-data' service. 
+--}}


### PR DESCRIPTION
Normal HTML comments are included in the DOM when rendered, but Handlebars style comments are not. In general, we probably do not want folks inspecting the source to see these comments and switching them to Handlebars comments fixes that.