### PR TITLE
remove unneeded slash on meta elements per HTML5 and ember-cli-template-lint

### DIFF
--- a/addon/templates/components/head-layout.hbs
+++ b/addon/templates/components/head-layout.hbs
@@ -1,1 +1,1 @@
-<meta name="ember-cli-head-start" />{{head-content}}<meta name="ember-cli-head-end" />
+<meta name="ember-cli-head-start">{{head-content}}<meta name="ember-cli-head-end">


### PR DESCRIPTION
Hello!  Fantastic addon!  Thank you for all your work.

I recently installed the popular `ember-cli-template-lint` addon.  
https://github.com/rwjblue/ember-cli-template-lint

This gives me errors when serve with `ember-cli-head` because the closing slash on HTML meta elements is unneeded and technically out of spec.  The closing slash is unlikely to cause any real world problems.  But other people are likely to get this error from `ember-cli-template-lint`.

So this pull request simply removes the redundant closing slashes.

`<meta name="ember-cli-head-start" />...<meta name="ember-cli-head-end" />`
becomes
`<meta name="ember-cli-head-start">...<meta name="ember-cli-head-end">`

Here is the error:
```
self-closing-void-elements: Self-closing a void element is redundant (modules/ember-cli-head/templates/components/head-layout): 
`<meta name="ember-cli-head-start" />`
self-closing-void-elements: Self-closing a void element is redundant (modules/ember-cli-head/templates/components/head-layout @ L1:C52): 
`<meta name="ember-cli-head-end" />`
===== 2 Template Linting Errors
```

https://github.com/rwjblue/ember-template-lint/#self-closing-void-elements
http://stackoverflow.com/a/19510239/1083851