### PR TITLE
include a default head template in app

### DIFF
--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -1,0 +1,2 @@
+<!-- ember-cli-head/templates/head.hbs -->
+<!-- If you see this your application's `head.hbs` has gone missing. -->


### PR DESCRIPTION
So we don't hard error if a consuming app misplaced their head.hbs

Resolves #7 

/cc @rwjblue @openhouse