### PR TITLE
Option to Suppress Removal of Fastboot Injected Head

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ This will result in a document along the lines of:
 
     <link rel="stylesheet" href="assets/vendor.css">
     <link rel="stylesheet" href="assets/my-app.css">
-    
+
     <meta property="og:title" content="Demo App">
   </head>
   <body class="ember-application">
-    
+
 
     <script src="assets/vendor.js"></script>
     <script src="assets/my-app.js"></script>
@@ -96,6 +96,8 @@ This will result in a document along the lines of:
   </body>
 </html>
 ```
+
+
 
 ### Fastboot Only
 
@@ -114,3 +116,18 @@ module.exports = function(environment) {
 ```
 
 If you make use of this mode the content of `<head>` will be the static FastBoot rendered content through the life of your App.
+
+### Suppress Clearing Fastbooted Head
+As noted above, by default, this library will remove the server rendered head content. However, if you are injecting model/route specific css (i.e. a customer specific theme) into the head, having that removed when the Ember app boots in the browser will cause your page to lose it's styling.
+
+This behavior can be suppressed by adding the following to your `config/environment.js`:
+
+```javascript
+module.exports = function(environment) {
+  var ENV = {
+    'ember-cli-head': {
+        suppressClearFastbootedHead: true
+    }
+  };
+}
+```

--- a/app-lt-2-10/instance-initializers/browser/head.js
+++ b/app-lt-2-10/instance-initializers/browser/head.js
@@ -4,11 +4,15 @@ import ENV from '../../config/environment';
 export function initialize(instance) {
   if (ENV['ember-cli-head'] && ENV['ember-cli-head']['suppressBrowserRender']) { return true; }
 
-  // clear fast booted head (if any)
-  Ember.$('meta[name="ember-cli-head-start"]')
-    .nextUntil('meta[name="ember-cli-head-end"] ~')
-    .addBack()
-    .remove();
+  if (ENV['ember-cli-head'] && ENV['ember-cli-head']['suppressClearFastbootedHead']) {
+    //do nothing...
+  }else{
+    // clear fast booted head (if any)
+    Ember.$('meta[name="ember-cli-head-start"]')
+      .nextUntil('meta[name="ember-cli-head-end"] ~')
+      .addBack()
+      .remove();
+  }
   const container = instance.lookup ? instance : instance.container;
   // const renderer = container.lookup('renderer:-dom');
   const component = container.lookup('component:head-layout');

--- a/app/instance-initializers/browser/head.js
+++ b/app/instance-initializers/browser/head.js
@@ -4,11 +4,15 @@ import ENV from '../../config/environment';
 export function initialize(owner) {
   if (ENV['ember-cli-head'] && ENV['ember-cli-head']['suppressBrowserRender']) { return true; }
 
-  // clear fast booted head (if any)
-  Ember.$('meta[name="ember-cli-head-start"]')
-    .nextUntil('meta[name="ember-cli-head-end"] ~')
-    .addBack()
-    .remove();
+  if (ENV['ember-cli-head'] && ENV['ember-cli-head']['suppressClearFastbootedHead']) {
+    //do nothing...
+  }else{
+    // clear fast booted head (if any)
+    Ember.$('meta[name="ember-cli-head-start"]')
+      .nextUntil('meta[name="ember-cli-head-end"] ~')
+      .addBack()
+      .remove();
+  }
 
   const component = owner.lookup('component:head-layout');
   component.appendTo(document.head);


### PR DESCRIPTION
We are injecting css (via `<link rel="stylesheet" href="{{model.css}}">`) into the head - and this addon works just great running only in the browser.

However, when we run in fastboot, the page initially loads with the correct stylesheet, but then as Ember boots and this addon's initiatlizers fire, the `<link >` tags are removed... only to be readded once the app pulls the model out of the shoebox and determines it needs to add a theme. This (of course) causes a flash of unstyled (un-themed in our case) content.

To get around this, I have added an option `suppressClearFastbootedHead`, and when set to true, the initializers simply skip removing the content.

All tests continue to pass, and I have updated the README.md - if you want me to create an issue first, or you have a better way to implement this, please let me know.