### PR TITLE
Check ember-source version from NPM, if not found use ember from bower

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,11 @@ module.exports = {
 
   treeForApp: function(defaultTree) {
     var checker = new VersionChecker(this);
-    var emberVersion = checker.for('ember', 'bower');
+    var emberVersion = checker.for('ember-source', 'npm');
+
+    if (!emberVersion.version) {
+      emberVersion = checker.for('ember', 'bower');
+    }
 
     var trees = [defaultTree];
 


### PR DESCRIPTION
This addon breaks when using with ember-source 2.11.0 from NPM instead of having ember from bower.