### PR TITLE
Use preconcatTree hook for filterInitializers

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,10 @@ module.exports = {
 
     var tree = mergeTrees(trees, { overwrite: true });
 
-    return filterInitializers(tree);
+    return mergeTrees(trees, { overwrite: true });
+  },
+
+  preconcatTree: function(tree) {
+    return filterInitializers(tree, this.app.name);
   }
 };


### PR DESCRIPTION
When upgrading an app to ember-cli 2.13, the FastBoot support of this addon stopped working. I noticed it used the `treeForApp` hook instead of `preconcatTree` to apply the `filterInitializers`. Changing that fixed the problem.

This is a quick fix until #21 lands...