### PR TITLE
Remove jQuery usage from the browser initializer and test suite

### DIFF
--- a/app-lt-2-10/instance-initializers/browser/head.js
+++ b/app-lt-2-10/instance-initializers/browser/head.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import ENV from '../../config/environment';
 
 export function initialize(instance) {

--- a/app-lt-2-10/instance-initializers/browser/head.js
+++ b/app-lt-2-10/instance-initializers/browser/head.js
@@ -5,10 +5,18 @@ export function initialize(instance) {
   if (ENV['ember-cli-head'] && ENV['ember-cli-head']['suppressBrowserRender']) { return true; }
 
   // clear fast booted head (if any)
-  Ember.$('meta[name="ember-cli-head-start"]')
-    .nextUntil('meta[name="ember-cli-head-end"] ~')
-    .addBack()
-    .remove();
+  let metaStart = document.querySelector('meta[name="ember-cli-head-start"]');
+  let metaEnd = document.querySelector('meta[name="ember-cli-head-end"]');
+  if (metaStart && metaEnd) {
+    let element;
+    while ((element = metaStart.nextElementSibling) && element !== metaEnd) {
+      element.parentNode.removeChild(element);
+    }
+
+    metaStart.parentNode.removeChild(metaStart);
+    metaEnd.parentNode.removeChild(metaEnd);
+  }
+
   const container = instance.lookup ? instance : instance.container;
   // const renderer = container.lookup('renderer:-dom');
   const component = container.lookup('component:head-layout');

--- a/app/instance-initializers/browser/head.js
+++ b/app/instance-initializers/browser/head.js
@@ -5,10 +5,17 @@ export function initialize(owner) {
   if (ENV['ember-cli-head'] && ENV['ember-cli-head']['suppressBrowserRender']) { return true; }
 
   // clear fast booted head (if any)
-  Ember.$('meta[name="ember-cli-head-start"]')
-    .nextUntil('meta[name="ember-cli-head-end"] ~')
-    .addBack()
-    .remove();
+  let metaStart = document.querySelector('meta[name="ember-cli-head-start"]');
+  let metaEnd = document.querySelector('meta[name="ember-cli-head-end"]');
+  if (metaStart && metaEnd) {
+    let element;
+    while ((element = metaStart.nextElementSibling) && element !== metaEnd) {
+      element.parentNode.removeChild(element);
+    }
+
+    metaStart.parentNode.removeChild(metaStart);
+    metaEnd.parentNode.removeChild(metaEnd);
+  }
 
   const component = owner.lookup('component:head-layout');
   component.appendTo(document.head);

--- a/app/instance-initializers/browser/head.js
+++ b/app/instance-initializers/browser/head.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import ENV from '../../config/environment';
 
 export function initialize(owner) {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.6.0",
+    "ember-native-dom-helpers": "^0.4.0",
     "ember-resolver": "^2.0.3",
     "ember-source": "~2.12.0",
     "loader.js": "^4.2.3"

--- a/tests/integration/components/head-layout-test.js
+++ b/tests/integration/components/head-layout-test.js
@@ -1,15 +1,14 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { findAll } from 'ember-native-dom-helpers';
 
 moduleForComponent('head-layout', 'Integration | Component | head layout', {
   integration: true
 });
 
 test('it renders', function(assert) {
-
   this.render(hbs`{{head-layout}}`);
 
-  assert.equal(this.$('meta[name="ember-cli-head-start"]').length, 1);
-  assert.equal(this.$('meta[name="ember-cli-head-end"]').length, 1);
-
+  assert.equal(findAll('meta[name="ember-cli-head-start"]').length, 1);
+  assert.equal(findAll('meta[name="ember-cli-head-end"]').length, 1);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1058,7 +1058,7 @@ broccoli-funnel-reducer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
 
-broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6:
+broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6, broccoli-funnel@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz#cddc3afc5ff1685a8023488fff74ce6fb5a51296"
   dependencies:
@@ -1774,7 +1774,7 @@ ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.10, ember-cli-babel@^5.1.5, ember-c
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
 
-ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.7:
+ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.0.0-beta.9:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.0.0.tgz#caab075780dca3759982c9f54ea70a9adb1f3550"
   dependencies:
@@ -2086,6 +2086,13 @@ ember-load-initializers@^0.6.0:
   resolved "https://registry.yarnpkg.com/ember-load-initializers/-/ember-load-initializers-0.6.3.tgz#f47396ad271ba77294068c98f992a5f19705441a"
   dependencies:
     ember-cli-babel "^5.1.6"
+
+ember-native-dom-helpers@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.4.0.tgz#dd0a706542204adc7c3b3a5fc4fff47339c280cb"
+  dependencies:
+    broccoli-funnel "^1.1.0"
+    ember-cli-babel "^6.0.0-beta.9"
 
 ember-qunit@^2.0.0-beta.1:
   version "2.1.2"


### PR DESCRIPTION
I'm on a mission to remove jQuery from my Ember app. This addon uses jQuery to remove all elements between the two meta tags that get injected (as well as the meta tags themselves).

This PR uses native DOM methods to walk the siblings between the start and end tags and removes all nodes between them. This is IE9 compatible, but let me know if there are any changes you'd like to see