### PR TITLE
Fix duplicate initializers appearing in dist js file

### DIFF
--- a/app-lt-2-10/instance-initializers/browser/head.js
+++ b/app-lt-2-10/instance-initializers/browser/head.js
@@ -1,12 +1,12 @@
-import ENV from '../config/environment';
+import ENV from '../../config/environment';
 
-export function initialize(owner) {
+export function initialize(instance) {
   if (ENV['ember-cli-head'] && ENV['ember-cli-head']['suppressBrowserRender']) { return true; }
 
   // clear fast booted head (if any)
   let startMeta = document.querySelector('meta[name="ember-cli-head-start"]')
   let endMeta = document.querySelector('meta[name="ember-cli-head-end"]')
-  if (startMeta && endMeta) {
+  if (startMeta && startMeta) {
     let el = startMeta.nextSibling
     while(el && el !== endMeta) {
       document.head.removeChild(el);
@@ -16,7 +16,9 @@ export function initialize(owner) {
     document.head.removeChild(endMeta);
   }
 
-  const component = owner.lookup('component:head-layout');
+  const container = instance.lookup ? instance : instance.container;
+  // const renderer = container.lookup('renderer:-dom');
+  const component = container.lookup('component:head-layout');
   component.appendTo(document.head);
 }
 

--- a/app/instance-initializers/browser/head.js
+++ b/app/instance-initializers/browser/head.js
@@ -1,12 +1,12 @@
-import ENV from '../config/environment';
+import ENV from '../../config/environment';
 
-export function initialize(instance) {
+export function initialize(owner) {
   if (ENV['ember-cli-head'] && ENV['ember-cli-head']['suppressBrowserRender']) { return true; }
 
   // clear fast booted head (if any)
   let startMeta = document.querySelector('meta[name="ember-cli-head-start"]')
   let endMeta = document.querySelector('meta[name="ember-cli-head-end"]')
-  if (startMeta && startMeta) {
+  if (startMeta && endMeta) {
     let el = startMeta.nextSibling
     while(el && el !== endMeta) {
       document.head.removeChild(el);
@@ -16,9 +16,7 @@ export function initialize(instance) {
     document.head.removeChild(endMeta);
   }
 
-  const container = instance.lookup ? instance : instance.container;
-  // const renderer = container.lookup('renderer:-dom');
-  const component = container.lookup('component:head-layout');
+  const component = owner.lookup('component:head-layout');
   component.appendTo(document.head);
 }
 


### PR DESCRIPTION
(Note: This error could only be seen when using a project using https://github.com/ronco/ember-cli-meta-tags. If just running ember-cli-meta-tags, this error doesn't appear.)

### The error:
When running `ember s` on our project (which we'll call `project-name`), we would get this console error: `"Assertion Failed: The instance initializer 'head-browser' has already been registered"`. (https://puu.sh/w7HJm/fd018e7dc1.png)

On investigation, in `dist/assets/project-name.js`, there were two initializers when there should only have been one, which is what was causing this error to appear.

The first one:
```
define('project-name/instance-initializers/head', ['exports', 'ember', 'bidvine-web/config/environment'], function (exports, _ember, _environment) {
  'use strict';

  Object.defineProperty(exports, "__esModule", {
    value: true
  });
  exports.initialize = undefined;
  function _initialize(owner) {
    if (_environment.default['ember-cli-head'] && _environment.default['ember-cli-head']['suppressBrowserRender']) {
      return true;
    }

    // clear fast booted head (if any)
    _ember.default.$('meta[name="ember-cli-head-start"]').nextUntil('meta[name="ember-cli-head-end"] ~').addBack().remove();

    var component = owner.lookup('component:head-layout');
    component.appendTo(document.head);
  }

  exports.initialize = _initialize;
  exports.default = {
    name: 'head-browser',
    initialize: function initialize() {
      if (typeof FastBoot === 'undefined') {
        _initialize.apply(undefined, arguments);
      }
    }
  };
});
```

The second one:
```
define('project-name/instance-initializers/browser/head', ['exports', 'ember', 'bidvine-web/config/environment'], function (exports, _ember, _environment) {
  'use strict';

  Object.defineProperty(exports, "__esModule", {
    value: true
  });
  exports.initialize = initialize;
  function initialize(owner) {
    if (_environment.default['ember-cli-head'] && _environment.default['ember-cli-head']['suppressBrowserRender']) {
      return true;
    }

    // clear fast booted head (if any)
    _ember.default.$('meta[name="ember-cli-head-start"]').nextUntil('meta[name="ember-cli-head-end"] ~').addBack().remove();

    var component = owner.lookup('component:head-layout');
    component.appendTo(document.head);
  }

  exports.default = {
    name: 'head-browser',
    initialize: initialize
  };
});
```
### My guess of what the problem is
Between 0.2.0 and 0.2.1, the non-fastboot initializers were moved from `{{appFolderName}}/instance-initializers/browser/head.js` to `{{appFolderName]}/instance-initializers/head.js`, while the fastboot initializers remained in `{{appFolderName}}/instance-initializers/fastboot/head.js`.

In ember-cli-head/app/index.js, `broccoli-merge-trees` is used to select the path to be used for the initializer. I think the different folder depth level of the fastboot vs non-fastboot initializers is causing broccoli-merge-trees to not merge the paths correctly, causing two initializers to be in the final distributed file.

### The fix
Moved the non-fastboot initializers back to their original folders, in `{{appFolderName}}/instance-initializers/browser/head.js`. Regardless of what the precise cause is, I tested this solution and it does indeed fix the problem.