### PR TITLE
Fix #84: declare `title` as a tracked property in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ export default class ApplicationRoute extends Route {
 }
 ```
 
+### Declare `title` as a tracked property on the `head-data` service
+
+```javascript
+// app/services/head-data.js
+
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class HeadDataService extends Service {
+  @tracked title;
+}
+```
 
 ### Using the service in head template
 


### PR DESCRIPTION
Forgetting to declare `title` as a tracked property is a silly but important omission. So thought it's best to document it in the README!